### PR TITLE
Fix #4 - remove cast from sql query 

### DIFF
--- a/lots/static/js/largelots_pilot2.js
+++ b/lots/static/js/largelots_pilot2.js
@@ -153,7 +153,8 @@ var LargeLots = {
         LargeLots.map.removeLayer(LargeLots.lastClickedLayer);
       }
       var sql = new cartodb.SQL({user: 'opencleveland', format: 'geojson'});
-      sql.execute('SELECT * from joined WHERE ppn = cast({{num}} as text)', {num:ppn_current}) //cast({{ppn}} as text)', {ppn:ppn})
+	  //Issue #4: using apostrophes instead of casting to keep leading zeros. - ASKoiman 12/6/2014
+      sql.execute('SELECT * from joined WHERE ppn = \'{{num}}\'', {num:ppn_current})
         .done(function(data){
             var shape = data.features[0];
             console.log(ppn_current);


### PR DESCRIPTION
thanks for fixing @arielkoiman :) 

I don't know why the source has needed to cast it in the first place because cartodb detected the ppn column as a string instead of a number. I think cartodb automatically detects the type of data (string, a number/integer, or the geometry) for each column when you upload the data to cartodb... 
